### PR TITLE
fix: prevent erro identifier is missing, add date

### DIFF
--- a/bookfinder/src/app/api/v1/book/route.ts
+++ b/bookfinder/src/app/api/v1/book/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: Request) {
   }
 
   const data = await fetch(googleUrl);
+
   const { items } = await data.json();
 
   if (!items) {
@@ -38,7 +39,11 @@ export async function GET(request: Request) {
       author: book.volumeInfo.authors,
       publisher: book.volumeInfo.publisher,
       imageLinks: book.volumeInfo.imageLinks,
-      identifier: book.volumeInfo.industryIdentifiers[0].identifier,
+      identifier:
+        book.volumeInfo.industryIdentifiers === undefined
+          ? ""
+          : book.volumeInfo.industryIdentifiers[0].identifier,
+      date: book.volumeInfo.publishedDate,
     };
   });
 


### PR DESCRIPTION
Fix error, when identifier was missing in google error
Add date to the returned data